### PR TITLE
Added Event::Data to String conversion

### DIFF
--- a/src/telnet_client.rs
+++ b/src/telnet_client.rs
@@ -11,7 +11,13 @@ pub fn send_message(client: &mut Telnet, msg: &str) {
 
 pub fn read_message(client: &mut Telnet) -> Option<String> {
     match client.read() {
-        Ok(event) => Some(format!("{:?}", event)),
+        Ok(event) => match event {
+            telnet::Event::Data(data) => {
+                let msg = String::from_utf8_lossy(&data[..]);
+                Some(format!("{}", msg.trim()))
+            }
+            _ => None,
+        },
         Err(_) => None,
     }
 }


### PR DESCRIPTION
# Overview
- Client now converts the server response from `[u8]` to `String` before printing.

### Previously:
```
Connected! Type messages:
> Hello World!
[server] Data([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 10, 10])
>
```
### Now:
```
Connected! Type messages:
> Hello World!
[server] Hello World!
>
```
