### PR TITLE
Added cargo aliases to easily run the project

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[alias]
+bc = "build --bin client"
+bs = "build --bin server"
+rc = "run --bin client"
+rs = "run --bin server"


### PR DESCRIPTION
# Overview
Eu estava achando um saco ter que digitar `cargo run --bin server/client` toda vez que ia rodar o projeto. 
Então eu criei alguns aliases para facilitar esse processo. Eles são:
- `cargo rc`: "cargo run" cliente;
- `cargo rs`: "cargo run" servidor;
- `cargo bc`: "cargo build" cliente;
- `cargo bs`: "cargo build" servidor.